### PR TITLE
Remove --headless from iri call

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -976,8 +976,6 @@ var App = (function(App, undefined) {
         params.push(settings.nodes.join(" "));
       }
 
-      params.push("--headless");
-
       console.log(params.join(" "));
 
       serverOutput = [];


### PR DESCRIPTION
I had to remove headless option to make full node start, otherwise it complained:
```
06/14 20:40:50.377 [main] ERROR com.iota.iri.IRI - CLI error: 
com.sanityinc.jargs.CmdLineParser$UnknownOptionException: Unknown option '--headless'
        at com.sanityinc.jargs.CmdLineParser.parse(CmdLineParser.java:556) ~[iri-1.2.1.jar:na]
        at com.sanityinc.jargs.CmdLineParser.parse(CmdLineParser.java:510) ~[iri-1.2.1.jar:na]
        at com.iota.iri.IRI.validateParams(IRI.java:126) [iri-1.2.1.jar:na]
        at com.iota.iri.IRI.main(IRI.java:51) [iri-1.2.1.jar:na]

06/14 20:40:50.381 [main] INFO  com.iota.iri.IRI - Usage: java -jar IRI-1.2.1.jar [{-n,--neighbors} '<list of neighbors>'] [{-p,--port} 14600] [{-c,--config} 'config-file-name'] [{-u,--udp-receiver-port} 14600] [{-t,--tcp-receiver-port} 15600] [{-d,--debug} false] [{--testnet} false][{--remote} false][{--remote-auth} string][{--remote-limit-api} string]
```