### PR TITLE
Fix threshold typo

### DIFF
--- a/ui/js/ui.transfers.js
+++ b/ui/js/ui.transfers.js
@@ -64,7 +64,7 @@ var UI = (function(UI, $, undefined) {
 
       UI.isDoingPOW = true;
 
-      iota.api.getInputs(connection.seed, {"treshold": amount}, function (error, inputs) {
+      iota.api.getInputs(connection.seed, {"threshold": amount}, function (error, inputs) {
         if (error) {
           UI.isDoingPOW = false;
           UI.formError("transfer", error, {"initial": "send_it_now"});


### PR DESCRIPTION
Typo in the send transfer section makes the wallet much slower at detecting whether it can afford to send a payment.