### PR TITLE
Fix for "invalid transfers object" error.

### DIFF
--- a/ui/js/ui.transfers.js
+++ b/ui/js/ui.transfers.js
@@ -38,7 +38,7 @@ var UI = (function(UI, $, undefined) {
         if (!rawAmount) {
           throw UI.t("amount_cannot_be_zero");
         } else {
-          amount = iota.utils.convertUnits(parseFloat(rawAmount), rawUnits, "i");
+          amount = parseInt(iota.utils.convertUnits(parseFloat(rawAmount), rawUnits, "i"), 10);
 
           if (!amount) {
             throw UI.t("amount_cannot_be_zero");


### PR DESCRIPTION
`utils.convertUnits()` should return an integer here. But some amounts return a float (like 2.019 Mi results in 2019000.0000000002) which leads to the `invalid transfers object` error. Here I propose a simple fix by forcing an integer for `amount`. In my tests `invalid transfers object` has not occured anymore on any value.